### PR TITLE
Amend the Valid WARC Regex.

### DIFF
--- a/pywb/recorder/s3uploader.py
+++ b/pywb/recorder/s3uploader.py
@@ -43,7 +43,7 @@ def s3_upload_file(filename: str, bucket: str=None, object_name=None):
 
 
 def validate_warc_filename(filename: str):
-    warc_pattern = r'collections\/[\w\-]+\/archive\/[\w\-]+\.warc\.gz'
+    warc_pattern = r'collections\/[\w\-]+\/archive\/[\w\-.]+\.warc\.gz'
     if not re.match(warc_pattern, filename):
         raise WARCValidationError(f'File {filename} is not a valid warc path')
 


### PR DESCRIPTION
Include the `.` in the list of valid WARC filename characters: running
this in AWS results in filenames similar to
`rec-{timestamp}-{ip}.eu-west-1.compute.internal.warc.gz`.